### PR TITLE
feat: shutdown the LSP properly when shutting down the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ async function main() {
 
   try {
     await app.start();
+    await app.runTillFinished()
   } catch (e: any) {
     logger.error(e.toString?.());
     process.exit(1);

--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -57,6 +57,7 @@ describe("LSP protocol tests", () => {
 			new StreamMessageReader(pair_b_read),
 			new StreamMessageWriter(pair_a_write),
 		);
+		server_connection.onRequest(protocol.ShutdownRequest.type, async () => {});
 		client = new LspClientImpl(
 			"id",
 			[],
@@ -203,9 +204,17 @@ describe("LSP protocol tests", () => {
 			expect(changed).toBe(true);
 			expect(saved).toBe(true);
 		});
+		test("Shutdown", async () => {
+			let shutdown = false;
+			server_connection.onRequest(protocol.ShutdownRequest.type, async () => {
+				shutdown = true;
+			});
+			await client.dispose();
+			expect(shutdown).toBe(true);
+		});
 	});
-	afterEach(() => {
-		client.dispose();
+	afterEach(async () => {
+		await client.dispose();
 		server_connection?.dispose();
 	});
 });

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -11,7 +11,7 @@ export interface LspClient {
   capabilities: protocol.ServerCapabilities | undefined;
   start(): Promise<void>;
   isStarted(): boolean;
-  dispose: () => void;
+  dispose: () => Promise<void>;
   sendRequest(method: string, args: any): Promise<any>;
   sendNotification(method: string, args: any): Promise<void>;
   openFileContents(uri: string, contents: string): Promise<void>;
@@ -231,8 +231,9 @@ export class LspClientImpl implements LspClient {
     }
   }
 
-  dispose() {
+  async dispose() {
     try {
+      await this.connection?.sendRequest(protocol.ShutdownRequest.type)
       this.logger.log(`LSP: Killing ${this.command} ${this.args}`);
       this.connection?.dispose();
       this.childProcess?.kill();


### PR DESCRIPTION
This PR ensures the LSP is properly shut down appropriately. 
To do this we:
1. Send the shutdown request to the LSP to use the standard shutdown protocol
2. Add a method to wait for stdin to close and then disposing of the server. This works around cases where SIGKILL isn't sent to the process. The reason for doing this instead of relying on the SDK/transport's handlers is that they haven't worked in my testing.
