### PR TITLE
feat: Eager Startup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -213,6 +213,11 @@ export class App {
   }
 
   public async start(transport: Transport = new StdioServerTransport()) {
+    await Promise.all(this.lspManager.getLsps().map(async (lsp) => {
+      if(lsp.eagerStartup) {
+        await lsp.start()
+      }
+    }))
     await this.registerTools(),
     await this.initializeMcp(),
     await startMcp(this.mcp, transport);
@@ -276,6 +281,7 @@ export class App {
           lspConfig.languages,
           lspConfig.extensions,
           this.workspace,
+          lspConfig.eagerStartup ?? false,
           lspConfig.command,
           lspConfig.args,
           flattenJson(lspConfig.settings ?? {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ const ConfigSchema = z.object({
       command: z.string(),
       args: z.array(z.string()),
       settings: z.optional(z.record(jsonSchema)),
+      eagerStartup: z.optional(z.boolean(), {description:"Start language when the MCP is initialized"}),
     }),
   ),
   methods: z.optional(z.array(z.string()), {

--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -63,6 +63,7 @@ describe("LSP protocol tests", () => {
 			[],
 			[],
 			WORKSPACE,
+			true,
 			"",
 			[],
 			flattenJson(SETTINGS),

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -8,6 +8,7 @@ export interface LspClient {
   id: string;
   languages: string[];
   extensions: string[];
+  eagerStartup: boolean;
   capabilities: protocol.ServerCapabilities | undefined;
   start(): Promise<void>;
   isStarted(): boolean;
@@ -35,6 +36,7 @@ export class LspClientImpl implements LspClient {
     public readonly languages: string[],
     public readonly extensions: string[],
     public readonly workspace: string,
+    public readonly eagerStartup: boolean,
     private readonly command: string,
     private readonly args: string[],
     private readonly settings: object,


### PR DESCRIPTION
This adds a configuration option to eagerly start the LSP on MCP start. While this doesn't initiate parsing of the repository, it does make lsp_info work from the get go and removes the initial setup from the first tool call.