### PR TITLE
(Optional) Enable markdown

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -125,12 +125,31 @@ export class LspClientImpl implements LspClient {
       workspace: {
         configuration: true,
       },
+      general: {
+        markdown: {
+          parser: "Python-Markdown",
+          version: "3.2.2"
+        }
+      },
       textDocument: {
         synchronization: {
           dynamicRegistration: true,
           didSave: true,
         },
-      },
+        completion: {
+          completionItem: {
+            documentationFormat: [protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText],
+          }
+        },
+        signatureHelp: {
+          signatureInformation: {
+            documentationFormat: [protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText],
+          }
+        },
+        hover: {
+          contentFormat: [protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText],
+        }
+      }
     };
     const uri = `file://${this.workspace}`;
     const response = await connection.sendRequest(InitializeRequest.type, {


### PR DESCRIPTION
This enables Markdown support in the hover, completion, and signature help methods. This should make the documentation more useful for the agent. This PR doesn't noticeably alter the behavior in vtsls, but it's best to be spec compliant.