### PR TITLE
Support document symbol better

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -148,6 +148,10 @@ export class LspClientImpl implements LspClient {
         },
         hover: {
           contentFormat: [protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText],
+        },
+        documentSymbol: {
+          symbolKind: { valueSet: Object.values(protocol.SymbolKind) },
+          hierarchicalDocumentSymbolSupport: true,
         }
       }
     };


### PR DESCRIPTION
This enables printing out nested symbols in DocumentSymbol and enables all types of Document Symbols.