### PR TITLE
feat: diagnostics support

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -100,7 +100,18 @@ export class App {
         return JSON.stringify(result, null, 2)
       },
     });
-
+    this.toolManager.registerTool({
+      id: "get_diagnostics",
+      description: "Get all errors in the project",
+      inputSchema: {
+        type: "object" as "object",
+      },
+      handler: async () => {
+        const requests = this.lspManager.getLsps().map((lsp) => lsp.getDiagnostics())
+        const diagnostics = (await Promise.all(requests)).flat()
+        return JSON.stringify(diagnostics, null, 2)
+      }
+    })
     this.toolManager.registerTool({
       id: "file_contents_to_uri",
       description:


### PR DESCRIPTION
# Motivation
Add a tool to quickly report diagnostics (errors) in files modified by an agent. This lets us save the time on running the linter/typechecker/etc from scratch each time.
# Content
- Add push diagnostics support. These are stored in a map indexed by the URI of the file they belong to.
- Add a tool to get diagnostics across the entire workspace. The naive implementation here reloads opened files and waits for any pending progress reports to be completed. This may not work in practice.
## More context on the diagnostics algorithm. 
There are two modes of handling diagnostics:
- [Push Mode](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_publishDiagnostics): The client opens a file, the server re-indexes it and sends a list of all errors in said file.
- [Pull mode](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_pullDiagnostics): The client opens a file, asks for a list of all errors in that file and the server sends a response. This is a new feature added in recent LSP implementations but not in the one we [need](https://github.com/yioneko/vtsls/issues/26).

Since we need this to be tool call shaped, we need to convert push diagnostics from LSP to pull diagnostics from the MCP. Therefore the tool will:
1. Open all changed files. A future revision will be needed to address files edited by the agent but not called using the LSP
2. Wait for the LSP to re-index those files. Ideally we can use the version support to handle this.
3. Return the combined diagnostics for all files

I'm uncertain if there's a good way to do step 2. Therefore, an alternate strategy would be to
1. In the background, reindex all files
2. Do some attempt at 2 (IE: the progress reporting based implementation here) which is somewhat time sensitive but only for a few seconds.
3. Hope the latency of generating new tokens delays the tool call enough for 2 to be complete.

Either way, this is a first attempt and I'll build on the synchronization approach as we go.
### Workspace vs Document Diagnostics 
Additionally there is a distinction between workspace and document diagnostics:
- Workspace Diagnostics: Diagnostics for every file in the workspace
- Document Diagnostics: Diagnostics for the file in the request

However there is request sent to the server in Push diagnostics - therefore we'll get the diagnostics for all open files.
# Misc
- Adds a ShowDocument stub handler for showing the tsserver log path