### PR TITLE
Revert "Link support"

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -149,15 +149,6 @@ export class LspClientImpl implements LspClient {
         hover: {
           contentFormat: [protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText],
         },
-        definition: {
-          linkSupport: true
-        },
-        implementation: {
-          linkSupport: true
-        },
-        typeDefinition: {
-          linkSupport: true
-        },
         documentSymbol: {
           symbolKind: { valueSet: Object.values(protocol.SymbolKind) },
           hierarchicalDocumentSymbolSupport: true,


### PR DESCRIPTION
Reverts makenotion/lsp-mcp#14
I don't think the added information here is particularly relevant and I'd like to unblock updating from this repo.