### PR TITLE
misc: Support Workspace Folders

### DIFF
--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -111,11 +111,13 @@ describe("LSP protocol tests", () => {
 			server_connection.onRequest(
 				protocol.InitializeRequest.type,
 				async (params: protocol.InitializeParams) => {
+					const URI = `file://${WORKSPACE}`;
 					expect(params).toMatchObject({
 						initializationOptions: EXPECTED_SETTINGS,
 						capabilities: expect.any(Object),
 						processId: expect.any(Number),
-						rootUri: `file://${WORKSPACE}`,
+						rootUri: URI,
+						workspaceFolders: [expect.objectContaining({ uri: URI })],
 						trace: "verbose",
 					});
 					resolve();

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -133,11 +133,21 @@ export class LspClientImpl implements LspClient {
     })
 
     connection.listen();
+    const uri = `file://${this.workspace}`;
+    const workspaceFolders = [{ "uri": uri, "name": "project" }]
+    connection.onRequest(
+      protocol.WorkspaceFoldersRequest.type,
+      (): protocol.WorkspaceFolder[] => {
+
+        return workspaceFolders;
+      },
+    );
 
     // TODO: We should figure out how to specify the capabilities we want
     const capabilities: protocol.ClientCapabilities = {
       workspace: {
         configuration: true,
+        workspaceFolders: true,
       },
       general: {
         markdown: {
@@ -172,7 +182,6 @@ export class LspClientImpl implements LspClient {
         workDoneProgress: true
       }
     };
-    const uri = `file://${this.workspace}`;
     const token = this.registerProgress();
 
     this.logger.log(`LSP workspae: ${uri}`);
@@ -182,6 +191,7 @@ export class LspClientImpl implements LspClient {
       capabilities: capabilities,
       initializationOptions: this.settings,
       workDoneToken: token,
+      workspaceFolders: workspaceFolders,
       trace: "verbose"
     });
     this.logger.log(


### PR DESCRIPTION
# Motivation
Adds support for workspaceFolders since root_uri is deprecated. 
Note: This isn't actually needed, I split out the important [fix](https://app.graphite.dev/github/pr/makenotion/lsp-mcp/20).