### PR TITLE
misc: remove extra logs

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -108,9 +108,6 @@ export class LspClientImpl implements LspClient {
         const response = items.map((element) => {
           return this.settings;
         });
-        this.logger.log(
-          `LSP: Configuration response for ${items.length} items ${JSON.stringify(response)}`,
-        );
         return response;
       },
     );
@@ -227,17 +224,7 @@ export class LspClientImpl implements LspClient {
       workspaceFolders: workspaceFolders,
       trace: "verbose"
     });
-    this.logger.log(
-      `LSP init options ${JSON.stringify(this.settings, null, 2)}`,
-    );
 
-    this.logger.info(
-      `Client LSP capabilities: ${JSON.stringify(capabilities, null, 2)}`,
-    );
-
-    this.logger.info(
-      `Server LSP capabilities: ${JSON.stringify(response, null, 2)}`,
-    );
     this.capabilities = response.capabilities;
     await connection.sendNotification(
       protocol.InitializedNotification.type,


### PR DESCRIPTION
These logs (settings and capabilities) are always the same for every run. However, they are pretty large and make it difficult to read the rest of the logs. This PR removes them.