### PR TITLE
feat: Add option to get diagnostics for a single file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -102,12 +102,17 @@ export class App {
     });
     this.toolManager.registerTool({
       id: "get_diagnostics",
-      description: "Get all errors in the project",
+      description: "Get errors for a file/opened files in the project",
       inputSchema: {
         type: "object" as "object",
+        file: {
+          type: "string",
+          description: "The specific file to get diagnostics for. If not specified, will get diagnostics for all modified files.",
+        },
+        required: []
       },
-      handler: async () => {
-        const requests = this.lspManager.getLsps().map((lsp) => lsp.getDiagnostics())
+      handler: async (args) => {
+        const requests = this.lspManager.getLsps().map((lsp) => lsp.getDiagnostics(args?.file))
         const diagnostics = (await Promise.all(requests)).flat()
         return JSON.stringify(diagnostics, null, 2)
       }


### PR DESCRIPTION
# Motivation
- If the agent hasn't opened/changed any files or called any tools, it should still be able to get diagnostics on individual files
- Also enables related information support. IE:
```      
"relatedInformation": [
{
          "message": "The declaration was marked as deprecated here.",
            ...
}
]
```
# Contents
- Add an option to get diagnostics for a single file instead of all open files
