### PR TITLE
fix: only send save notifications if the server supports them

### DIFF
--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -229,7 +229,13 @@ describe("LSP protocol tests", () => {
 			server_connection.onRequest(
 				protocol.InitializeRequest.type,
 				async (params: protocol.InitializeParams) => {
-					return { capabilities: {} };
+					return {
+						capabilities: {
+							textDocumentSync: {
+								save: true,
+							},
+						},
+					};
 				},
 			);
 			server_connection.onNotification(

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -354,15 +354,17 @@ export class LspClientImpl implements LspClient {
 
   }
   async sendDidSave(uri: string, contents: string) {
-    await this.sendNotification(
-      protocol.DidSaveTextDocumentNotification.method,
-      {
-        textDocument: {
-          uri: uri,
+    if (typeof this.capabilities?.textDocumentSync === "object" && this.capabilities?.textDocumentSync?.save) {
+      await this.sendNotification(
+        protocol.DidSaveTextDocumentNotification.method,
+        {
+          textDocument: {
+            uri: uri,
+          },
+          text: contents,
         },
-        text: contents,
-      },
-    );
+      );
+    }
 
   }
   // Lets the LSP know about a file contents


### PR DESCRIPTION
Turns out vtsls doesn't support save notifications. This PR disables them if the server doesn't support them.