### PR TITLE
feat: Implement better checks around diagnostics refreshing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -244,10 +244,10 @@ export class App {
   }
 
   public async openFile(path: string) {
-    for (const lsp of this.lspManager.getLsps()) {
+    await Promise.all(this.lspManager.getLsps().map(async (lsp) => {
       const uri = pathToFileUri(path)
       await openFile(lsp, path, uri)
-    }
+    }))
   }
   public async runTillFinished() {
     await stream.finished(process.stdin, {})
@@ -309,6 +309,7 @@ export class App {
           this.workspace,
           lspConfig.eagerStartup ?? false,
           lspConfig.waitForConfiguration ?? false,
+          lspConfig.strictDiagnostics ?? false,
           lspConfig.command,
           lspConfig.args,
           flattenJson(lspConfig.settings ?? {}),

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,8 @@ const ConfigSchema = z.object({
       args: z.array(z.string()),
       settings: z.optional(z.record(jsonSchema)),
       eagerStartup: z.optional(z.boolean(), { description: "Start language when the MCP is initialized" }),
-      waitForConfiguration: z.optional(z.boolean(), { description: "Wait for the server to request configuration before starting" })
+      waitForConfiguration: z.optional(z.boolean(), { description: "Wait for the server to request configuration before starting" }),
+      strictDiagnostics: z.optional(z.boolean(), { description: "Wait for diagnostics to be reported for every file." }),
     }),
   ),
   methods: z.optional(z.array(z.string()), {


### PR DESCRIPTION
- Refactors logic that gets diagnostics. Instead of relying on progress, this PR adds an options to manually wait for diagnostics to be sent for every opened file.
- Fixes some of the promise/async logic and uses the newer Promise.withResolvers API