### PR TITLE
feat: prompt overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ export class App {
   private readonly workspace: string;
 
   constructor(
-    config: Config,
+    private readonly config: Config,
     protected readonly logger: Logger,
   ) {
     // keeps track of all the tools we're sending to the MCP
@@ -33,7 +33,7 @@ export class App {
     // keeps track of all the LSP Clients we're using
     this.lspManager = new LspManager(this.buildLsps(config.lsps, logger));
     // the MCP server
-    this.mcp = createMcp();
+    this.mcp = createMcp(config.instructions);
     // The LSP methods we support (textDocument/foo, etc)
     this.availableMethodIds = getLspMethods(config.methods);
 
@@ -187,10 +187,11 @@ export class App {
       if (lspProperty && inputSchema.properties) {
         inputSchema.properties[lspProperty.name] = lspProperty;
       }
+      const toolId = method.id.replace("/", "_")
 
       this.toolManager.registerTool({
-        id: method.id.replace("/", "_"),
-        description: method.description,
+        id: toolId,
+        description: this.config.perToolInstructions?.get(toolId) || method.description,
         inputSchema: inputSchema,
         handler: async (args, { sendNotification, _meta }) => {
           let lsp: LspClient | undefined;

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,10 @@ const ConfigSchema = z.object({
   workspace: z.optional(z.string(), {
     description: "Path to the workspace to use for the LSP. Defaults to /"
   }),
+  instructions: z.optional(z.string(), {
+    description: "Instructions on how to use lspMcp",
+  }),
+  perToolInstructions: z.optional(z.map(z.string(), z.string()), { description: "Optional description overrides for each tool" })
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -3,7 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 
 // Create an MCP server
-export function createMcp(): McpServer {
+export function createMcp(instructions?: string): McpServer {
   return new McpServer(
     {
       name: "LSP",
@@ -13,6 +13,7 @@ export function createMcp(): McpServer {
       capabilities: {
         tools: {},
       },
+      instructions
     },
   );
 }


### PR DESCRIPTION
We would like to give instructions on how to use lspMcp specific to our repo. This PR lets us override the base mcp prompt and the prompt for each tool. This way these prompts are bundled with the tools they're for and only applicable when the mcp is enabled.