### PR TITLE
refactor: Move the file read into openFileContents

### DIFF
--- a/src/FileWatcher.test.ts
+++ b/src/FileWatcher.test.ts
@@ -7,8 +7,8 @@ import { pathToFileUri } from "./lsp-methods"
 
 describe("File Watcher tests", () => {
 	let watcher: FileWatcher
-	const onAdd = vi.fn<(_: string, __: string) => Promise<void>>()
-	const onChange = vi.fn<(_: string, __: string) => Promise<void>>()
+	const onAdd = vi.fn<(_: string) => Promise<void>>()
+	const onChange = vi.fn<(_: string) => Promise<void>>()
 	const onRemove = vi.fn<(_: string) => Promise<void>>()
 	const testDir = path.resolve("__test__")
 	const target = join(testDir, "test.txt")
@@ -39,14 +39,14 @@ describe("File Watcher tests", () => {
 	test("Add File", async () => {
 		await writeFile(target, "test_Data")
 		await new Promise(r => setTimeout(r, 300))
-		expect(onAdd).toHaveBeenCalledWith(targetUri, "test_Data")
+		expect(onAdd).toHaveBeenCalledWith(targetUri)
 	})
 	test("Update File", async () => {
 		await writeFile(target, "test_Data")
 		await new Promise(r => setTimeout(r, 300))
 		await writeFile(target, "new_Data")
 		await new Promise(r => setTimeout(r, 300))
-		expect(onChange).toHaveBeenCalledWith(targetUri, "new_Data")
+		expect(onChange).toHaveBeenCalledWith(targetUri)
 	})
 	test("Remove File", async () => {
 		await writeFile(target, "test_Data")

--- a/src/FileWatcher.ts
+++ b/src/FileWatcher.ts
@@ -35,15 +35,9 @@ export class FileWatcher {
 		private readonly extensions: string[],
 		private readonly root: string,
 		private readonly logger: Logger,
-		private readonly onFileChanged: (
-			uri: string,
-			content: string,
-		) => Promise<void>,
+		private readonly onFileChanged: (uri: string) => Promise<void>,
 		private readonly onFileRemoved: (uri: string) => Promise<void>,
-		private readonly onFileCreated: (
-			uri: string,
-			content: string,
-		) => Promise<void>,
+		private readonly onFileCreated: (uri: string) => Promise<void>,
 	) {
 		this.events = []
 	}
@@ -70,10 +64,10 @@ export class FileWatcher {
 						const uri = pathToFileUri(path)
 						switch (type) {
 							case "update":
-								await this.onFileChanged(uri, await readFile(path, "utf-8"))
+								await this.onFileChanged(uri)
 								break
 							case "create":
-								await this.onFileCreated(uri, await readFile(path, "utf-8"))
+								await this.onFileCreated(uri)
 								break
 							case "delete":
 								await this.onFileRemoved(uri)

--- a/src/app.ts
+++ b/src/app.ts
@@ -252,7 +252,7 @@ export class App {
   public async openFile(path: string) {
     await Promise.all(this.lspManager.getLsps().map(async (lsp) => {
       const uri = pathToFileUri(path)
-      await openFile(lsp, path, uri)
+      await openFile(lsp, uri)
     }))
   }
   public async runTillFinished() {

--- a/src/lsp-methods.ts
+++ b/src/lsp-methods.ts
@@ -30,7 +30,7 @@ export function pathToFileUri(path: string): string {
 }
 
 // convert file:///path/to/file to /path/to/file
-function fileUriToPath(uri: string): string {
+export function fileUriToPath(uri: string): string {
   if (uri.startsWith("file://")) {
     return path.resolve(uri.slice(7));
   }
@@ -40,13 +40,12 @@ function fileUriToPath(uri: string): string {
 
 // Let's the LSP know about a file contents
 export async function openFileContents(lsp: LspClient, uri: string, contents: string): Promise<void> {
-  await lsp.openFileContents(uri, contents);
+  await lsp.openFileContents(uri);
 }
 
 // Lets the LSP know about a file
-export async function openFile(lsp: LspClient, file: string, uri: string): Promise<void> {
-  const contents = await fs.readFile(file, "utf8");
-  await openFileContents(lsp, uri, contents);
+export async function openFile(lsp: LspClient, uri: string): Promise<void> {
+  await lsp.openFileContents(uri);
 }
 
 export async function lspMethodHandler(lsp: LspClient, methodId: string, args: Record<string, any>): Promise<string> {
@@ -58,7 +57,7 @@ export async function lspMethodHandler(lsp: LspClient, methodId: string, args: R
     const file = fileUriToPath(lspArgs.textDocument.uri);
     const uri = pathToFileUri(file);
     // TODO: decide how to close the file. Timeout I think is the best option?
-    await openFile(lsp, file, uri);
+    await openFile(lsp, uri);
     lspArgs = { ...lspArgs, textDocument: { ...lspArgs.textDocument, uri } };
   }
 
@@ -75,7 +74,7 @@ async function getMetaModel() {
 
 async function getDereferencedJsonSchema() {
   const parser = new $RefParser()
-  const schema = await parser.parse(path.join(__dirname,"./resources/generated.protocol.schema.json"))
+  const schema = await parser.parse(path.join(__dirname, "./resources/generated.protocol.schema.json"))
 
   const dereferenced = await parser.dereference(schema, {
     mutateInputSchema: false,
@@ -131,7 +130,7 @@ export async function getLspMethods(
       }
     }
     const metaModelTool = metaModelLookup.get(id);
-    if (metaModelTool?.messageDirection != "clientToServer"){
+    if (metaModelTool?.messageDirection != "clientToServer") {
       return undefined
     }
     return {


### PR DESCRIPTION
Currently callers of openFileContents are responsible for reading the file themselves. This PR moves that call into openFileContents, reducing duplicated code.

I'm going to add a lock on this function in my next PR and want to ensure that the file is read inside the function, not outside the function. 
While some functions may still read the file contents and pass that to openFileContents, the file watcher doesn't. This should still prevent concurrency bugs.