### PR TITLE
feat: Workaround when diagnostics aren't reported for all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",


### PR DESCRIPTION
## Context
Whenever we change a file, we send a didChange notification. This translates to an updateOpen and getErr request to tsserver. Once it gets the response for that, it'll send a publishNotification notification back for each file we changed
## Problem
Sometimes the LSP won't report diagnostics for a file if we send multiple requests simultaneously and that file has no errors. This causes get_diagnostics to take forever. 
## Solution
If we receive the diagnostics for a file and have multiple requests pending, we will set the other requests to an empty response after 10 seconds. This could cause cases of type errors being missed, but those can always be caught later in CI. 