### PR TITLE
fix: Set a 5 minute timeout to handle diagnostics timing out

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,9 +114,17 @@ export class App {
       },
       handler: async (args) => {
         // Wait for 5 minutes
-        const requests = this.lspManager.getLsps().map((lsp) => Promise.race([lsp.getDiagnostics(args?.file), new Promise<Diagnostic[]>(resolve =>
-
-          setTimeout(() => { this.logger.error("Getting diagnostics timed out, returning empty result"); resolve([]) }, 300000))]))
+        const requests = this.lspManager.getLsps().map((lsp) => 
+          Promise.race([
+            lsp.getDiagnostics(args?.file), 
+            new Promise<Diagnostic[]>((resolve) => {
+              setTimeout(() => { 
+                this.logger.error("Getting diagnostics timed out, returning empty result"); 
+                resolve([]) 
+              }, 300000)
+            })
+          ])
+        )
         const diagnostics = (await Promise.all(requests)).flat()
         return JSON.stringify(diagnostics, null, 2)
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import { LspManager } from "./lsp-manager";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { promises as stream } from "node:stream"
+import { Diagnostic } from "vscode-languageserver-protocol";
 export class App {
   private readonly toolManager: ToolManager;
   private readonly lspManager: LspManager;
@@ -112,7 +113,10 @@ export class App {
         required: []
       },
       handler: async (args) => {
-        const requests = this.lspManager.getLsps().map((lsp) => lsp.getDiagnostics(args?.file))
+        // Wait for 5 minutes
+        const requests = this.lspManager.getLsps().map((lsp) => Promise.race([lsp.getDiagnostics(args?.file), new Promise<Diagnostic[]>(resolve =>
+
+          setTimeout(() => { this.logger.error("Getting diagnostics timed out, returning empty result"); resolve([]) }, 300000))]))
         const diagnostics = (await Promise.all(requests)).flat()
         return JSON.stringify(diagnostics, null, 2)
       }
@@ -240,13 +244,13 @@ export class App {
 
   public async start(transport: Transport = new StdioServerTransport()) {
     await Promise.all(this.lspManager.getLsps().map(async (lsp) => {
-      if(lsp.eagerStartup) {
+      if (lsp.eagerStartup) {
         await lsp.start()
       }
     }))
     await this.registerTools(),
-    await this.initializeMcp(),
-    await startMcp(this.mcp, transport);
+      await this.initializeMcp(),
+      await startMcp(this.mcp, transport);
   }
 
   public async openFile(path: string) {
@@ -296,11 +300,11 @@ export class App {
       type: type,
       properties: inputSchema.properties
         ? Object.fromEntries(
-            Object.entries(inputSchema.properties).map(([key, value]) => [
-              key,
-              this.removeInputSchemaInvariants(value),
-            ]),
-          )
+          Object.entries(inputSchema.properties).map(([key, value]) => [
+            key,
+            this.removeInputSchemaInvariants(value),
+          ]),
+        )
         : undefined,
     };
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import { LspManager } from "./lsp-manager";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { promises as stream } from "node:stream"
-import { Diagnostic } from "vscode-languageserver-protocol";
+import type { Diagnostic } from "vscode-languageserver-protocol";
 export class App {
   private readonly toolManager: ToolManager;
   private readonly lspManager: LspManager;


### PR DESCRIPTION
Sometimes the LSP will not send diagnostics back or you may have other issues. This adds a failsafe to make sure it returns something rather than take forever.
 
Since I don't have a consistent reproduction of the underlying bug, I can't easily test it. But this does work when the underlying call hasn't timed out.