### PR TITLE
misc: Log when timeouts occur

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -499,6 +499,7 @@ export class LspClientImpl implements LspClient {
     for (const file in this.files) {
       const old = this.files[file].resolvedDiagnostics
       this.files[file].resolvedDiagnostics = Promise.race([old, setTimeout(delay).then(() => {
+        this.logger.warn(`LSP: Diagnostics timed out for ${file}`)
         this.files[file].reportDiagnostics(diagnostics)
         return diagnostics
       })])


### PR DESCRIPTION
Right now, there's a case in which the server doesn't publish diagnostics. I implemented a workaround to handle this earlier.
This PR adds logs to indicate the workaround being used.