### PR TITLE
fix: Use previous result ID for unchanged responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -499,10 +499,15 @@ export class LspClientImpl implements LspClient {
         items = result.items
         break
       case "unchanged":
-        if (!this.previousDiagnostics.has(identifier)) {
-          this.logger.warn(`LSP: No diagnostics found for ${uri} with identifier ${identifier}`)
+        if(!previousResultId) {
+          this.logger.warn(`LSP: No previous result id found for ${uri}`)
+          items = []
+          break
         }
-        items = this.previousDiagnostics.get(identifier) ?? []
+        if (!this.previousDiagnostics.has(previousResultId)) {
+          this.logger.warn(`LSP: No diagnostics found for ${uri} with identifier ${previousResultId}`)
+        }
+        items = this.previousDiagnostics.get(previousResultId) ?? []
         break
     }
     this.previousDiagnostics.set(identifier, items)


### PR DESCRIPTION
When we send a request for diagnostics, we attach a previous result ID to avoid duplication. If the new request has identical results to the previous, we get an unchanged response.
The logic was slightly wrong, I used returned the results for the current result ID (for which there aren't any) accidentally instead of the previous result ID.