### PR TITLE
fix: Handle file read errors by closing the document

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",


### PR DESCRIPTION
Sometimes we'll be checking workspace diagnostics and a file will be closed but the file hasn't been removed from the list of files yet (IE if the file was closed but we haven't picked up the change yet with the file watcher). This causes an error when we try to read the contents of the file.

This PR adds error handling to reading the file to help with this situation.