### PR TITLE
feat: Add file path to diagnostics

### DIFF
--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -466,6 +466,14 @@ describe.each([
 						message: "error",
 					},
 				]
+				const expectedDiagnostics: protocol.Diagnostic[] = diagnostics.map(
+					diagnostic => {
+						return {
+							path: FILE_PATH.replace(`${WORKSPACE}/`, ""),
+							...diagnostic,
+						}
+					},
+				)
 				// The file needs to be opened to have diagnostics
 				await writeFile(FILE_PATH, "testContent")
 				const requestedDiagnostics = new Promise(resolve =>
@@ -490,7 +498,7 @@ describe.each([
 				} else {
 					await sendDiagnostics(server_connection, ABSOLUTE_URI, diagnostics)
 				}
-				expect(await getter).toEqual(diagnostics)
+				expect(await getter).toEqual(expectedDiagnostics)
 				// The file needs to be changed to get new diagnostics
 				diagnostics = []
 				await writeFile(FILE_PATH, "testContent2")
@@ -525,16 +533,26 @@ describe.each([
 						message: "error",
 					},
 				]
+				const expectedDiagnostics: protocol.Diagnostic[] = diagnostics.map(
+					diagnostic => {
+						return {
+							path: FILE_PATH.replace(`${WORKSPACE}/`, ""),
+							...diagnostic,
+						}
+					},
+				)
 				// The file needs to be opened to have diagnostics
 				await writeFile(FILE_PATH, "testContent")
 				await opened
 				if (!pullDiagnostics) {
 					await sendDiagnostics(server_connection, ABSOLUTE_URI, diagnostics)
 				}
-				expect(await client.getDiagnostics()).toEqual(diagnostics)
-				expect(await client.getDiagnostics(FILE_PATH)).toEqual(diagnostics)
+				expect(await client.getDiagnostics()).toEqual(expectedDiagnostics)
+				expect(await client.getDiagnostics(FILE_PATH)).toEqual(
+					expectedDiagnostics,
+				)
 				expect(await client.getDiagnostics(ABSOLUTE_FILE_PATH)).toEqual(
-					diagnostics,
+					expectedDiagnostics,
 				)
 				if (pullDiagnostics) {
 					const params = await requestedDiagnostics


### PR DESCRIPTION
When getting diagnostics for a project, we may return results for a lot of files and it may not be clear where the errors are. This PR attaches the filename to those errors.

![Screenshot 2025-08-14 at 1.45.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/qzcm2OIQTHFf5jNnexpp/c0c70468-058b-4a54-839e-533c9dbe1f6a.png)