### PR TITLE
Fix bad schema for get_diagnostics. See https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-with-default-2020-12-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -106,14 +106,16 @@ export class App {
       description: "Get errors for a file/opened files in the project",
       inputSchema: {
         type: "object" as "object",
-        file: {
-          type: "string",
-          description: "The specific file to get diagnostics for. If not specified, will get diagnostics for all modified files.",
-        },
-        page: {
-          type: "integer",
-          name: "page",
-          description: "Specifies which page of results to retrieve when there are more results than can fit in a single response. The first page is 0 and is the default.",
+        properties: {
+          file: {
+            type: "string",
+            description: "The specific file to get diagnostics for. If not specified, will get diagnostics for all modified files.",
+          },
+          page: {
+            type: "integer",
+            name: "page",
+            description: "Specifies which page of results to retrieve when there are more results than can fit in a single response. The first page is 0 and is the default.",
+          },
         },
         required: []
       },


### PR DESCRIPTION
See https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-with-default-2020-12-schema

Before fix:

![Screenshot 2026-02-19 at 11.44.46.png](https://app.graphite.com/user-attachments/assets/c6e8dc91-9eea-4914-952f-a377630dfa4a.png)



After fix:  


![image.png](https://app.graphite.com/user-attachments/assets/9b2a9b96-6a75-4054-b853-0ed86f453691.png)

