### PR TITLE
fix: Exclude .git directory from file watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/FileWatcher.ts
+++ b/src/FileWatcher.ts
@@ -88,6 +88,7 @@ export class FileWatcher {
 	async start() {
 		this.logger.info(`Reading gitignore from ${this.root}`)
 		const gitignore = await readGitIgnore(this.logger, this.root)
+		gitignore.push(".git/")
 		this.logger.info(
 			`Starting file watcher for ${JSON.stringify(this.root)} with extensions ${JSON.stringify(this.extensions)}`,
 		)


### PR DESCRIPTION
Sometimes the filewatcher will scan for changes in this directory
