### PR TITLE
feat: add configurable diagnosticsFileRequiredMessage

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -101,15 +101,20 @@ export class App {
         return JSON.stringify(result, null, 2)
       },
     });
+    const fileRequired = this.config.diagnosticsRequireFile ?? false;
     this.toolManager.registerTool({
       id: "get_diagnostics",
-      description: "Get errors for a file/opened files in the project",
+      description: fileRequired
+        ? "Get type errors for a specific file in the project"
+        : "Get errors for a file/opened files in the project",
       inputSchema: {
         type: "object" as "object",
         properties: {
           file: {
             type: "string",
-            description: "The specific file to get diagnostics for. If not specified, will get diagnostics for all modified files.",
+            description: fileRequired
+              ? "The file path to get diagnostics for (required)."
+              : "The specific file to get diagnostics for. If not specified, will get diagnostics for all modified files.",
           },
           page: {
             type: "integer",
@@ -117,7 +122,7 @@ export class App {
             description: "Specifies which page of results to retrieve when there are more results than can fit in a single response. The first page is 0 and is the default.",
           },
         },
-        required: []
+        required: fileRequired ? ["file"] : [],
       },
       handler: async (args) => {
         // Wait for 5 minutes

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,10 @@ const ConfigSchema = z.object({
   instructions: z.optional(z.string(), {
     description: "Instructions on how to use lspMcp",
   }),
-  perToolInstructions: z.optional(z.map(z.string(), z.string()), { description: "Optional description overrides for each tool" })
+  perToolInstructions: z.optional(z.map(z.string(), z.string()), { description: "Optional description overrides for each tool" }),
+  diagnosticsRequireFile: z.optional(z.boolean(), {
+    description: "When true, the `file` parameter becomes required for get_diagnostics.",
+  }),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;


### PR DESCRIPTION
## Description

Adds a `diagnosticsRequireFile` boolean config option that, when set to `true`, makes the `file` parameter required for the `get_diagnostics` tool.

**Motivation:** AI agents using the LSP MCP sometimes call `get_diagnostics` without a `file` parameter, thinking it performs a full-repo typecheck. In reality, it only returns diagnostics for files that have already been opened in the LSP session — which gives incomplete results and misleads agents into thinking the codebase is error-free.

In the Notion codebase, the correct way to do a full-repo typecheck is `notion typecheck --go`. We want to force agents to either check a specific file (fast, via LSP) or do a proper full typecheck (slow, via CLI) — not use the ambiguous middle ground.

**Changes:**
- `src/config.ts`: Added `diagnosticsRequireFile?: boolean` to the config schema
- `src/app.ts`: When `diagnosticsRequireFile` is true, `file` is added to `required` in the tool schema and descriptions update accordingly. Default behavior (file optional) is preserved when unset.

## How was this change tested?

- [ ] Automated test (unit, integration, etc.)
- [x] Manual test (provide reproducible testing steps below)

Configured `diagnosticsRequireFile: true` in the Notion LSP MCP wrapper, reconnected the MCP server, and verified:
1. Tool schema shows `file` in `required` array and description says "(required)"
2. Calling `get_diagnostics` with a `file` parameter returns diagnostics normally
3. MCP clients reject calls without `file` at the schema level

## Screenshots