### PR TITLE
feat: Send clientInfo in LSP initialize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apt install -y python3-pylsp
 
 COPY --from=builder /app/dist /app
 COPY --from=builder /app/node_modules /app/node_modules
+# dist is flattened into /app, so keep package.json next to it for version reporting
+COPY --from=builder /app/package.json /app/package.json
 
 # Cleanup
 RUN apt clean && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-mcp",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:jonrad/lsp-mcp.git",

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { promises as stream } from "node:stream"
 import type { Diagnostic } from "vscode-languageserver-protocol";
+import { buildClientInfo } from "./version";
 export class App {
   private readonly toolManager: ToolManager;
   private readonly lspManager: LspManager;
@@ -339,6 +340,7 @@ export class App {
           lspConfig.args,
           flattenJson(lspConfig.settings ?? {}),
           logger,
+          () => buildClientInfo(this.mcp.getClientVersion()),
         ),
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Command, OptionValues } from "commander";
 import { Config, loadConfig } from "./config";
 import { App } from "./app";
 import { Logger } from "vscode-languageserver-protocol";
+import { PACKAGE_VERSION } from "./version";
 
 async function buildConfig(options: OptionValues, logger: Logger): Promise<Config> {
   let config: Config | undefined;
@@ -57,7 +58,7 @@ async function main() {
   program
     .name("lsp-mcp")
     .description("A tool for providing LSP requests to MCP")
-    .version("0.1.0")
+    .version(PACKAGE_VERSION)
     .option(
       "-m, --methods [string...]",
       "LSP methods to enabled (Default: all)",

--- a/src/lsp.test.ts
+++ b/src/lsp.test.ts
@@ -17,6 +17,7 @@ import * as protocol from "vscode-languageserver-protocol"
 import { errorLogger } from "./logger"
 import { LspClientImpl } from "./lsp"
 import { flattenJson } from "./utils"
+import { PACKAGE_NAME, PACKAGE_VERSION } from "./version"
 
 async function sendProgress(
 	server_connection: rpc.MessageConnection,
@@ -152,6 +153,10 @@ describe.each([
 					const URI = `file://${WORKSPACE}`
 					expect(params).toMatchObject({
 						initializationOptions: EXPECTED_SETTINGS,
+						clientInfo: {
+							name: PACKAGE_NAME,
+							version: PACKAGE_VERSION,
+						},
 						capabilities: expect.any(Object),
 						processId: expect.any(Number),
 						rootUri: URI,

--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -13,6 +13,7 @@ import { setTimeout } from "timers/promises";
 import { Mutex } from "async-mutex";
 import { fileUriToPath, pathToFileUri } from "./lsp-methods";
 import path, { resolve } from "path";
+import { buildClientInfo } from "./version";
 
 export interface LspClient {
   id: string;
@@ -63,6 +64,8 @@ export class LspClientImpl implements LspClient {
     private readonly args: string[],
     private readonly settings: object,
     private readonly logger: Logger, // TODO: better long term solution for logging
+    // Resolved lazily since the agent isn't known until the MCP handshake completes
+    private readonly getClientInfo: () => { name: string; version: string } = () => buildClientInfo(),
   ) {
     this.capabilities = undefined;
     this.files = {};
@@ -248,6 +251,7 @@ export class LspClientImpl implements LspClient {
     this.logger.log(`LSP workspace: ${uri}`);
     const response = await connection.sendRequest(InitializeRequest.type, {
       processId: process.pid,
+      clientInfo: this.getClientInfo(),
       rootPath: this.workspace, // Used for eslint
       rootUri: uri, // Used by most lsps
       capabilities: capabilities,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,13 +1,14 @@
 import { Server as McpServer } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { PACKAGE_VERSION } from "./version";
 
 // Create an MCP server
 export function createMcp(instructions?: string): McpServer {
   return new McpServer(
     {
       name: "LSP",
-      version: "0.1.0",
+      version: PACKAGE_VERSION,
     },
     {
       capabilities: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,30 @@
+import type { Implementation } from "@modelcontextprotocol/sdk/types.js";
+
+// Required rather than imported so package.json stays out of the compiled output tree
+function readPackageJson(): { name: string; version: string } {
+  for (const candidate of ["../package.json", "./package.json"]) {
+    try {
+      return require(candidate);
+    } catch {
+      // Try the next layout
+    }
+  }
+  return { name: "lsp-mcp", version: "unknown" };
+}
+
+const pkg = readPackageJson();
+
+export const PACKAGE_NAME: string = pkg.name;
+export const PACKAGE_VERSION: string = pkg.version;
+
+// Identifies the agent driving us, with this library noted in the name
+export function buildClientInfo(agent?: Implementation): { name: string; version: string } {
+  if (!agent) {
+    return { name: PACKAGE_NAME, version: PACKAGE_VERSION };
+  }
+
+  return {
+    name: `${agent.name} (${PACKAGE_NAME} ${PACKAGE_VERSION})`,
+    version: agent.version || "unknown",
+  };
+}


### PR DESCRIPTION
Language servers previously received no `clientInfo` in `initialize`, so they had no idea who was talking to them.

Now we send the agent's name and version, with this library noted in the name: `{ name: "claude-code (lsp-mcp 1.4.0)", version: "2.0.42" }`. The agent isn't known until the MCP handshake completes, so it's resolved lazily at LSP start; eagerly-started LSPs fall back to `{ name: "lsp-mcp", version: "1.4.0" }`.

Version now comes from package.json instead of the stale hardcoded `0.1.0` in the MCP server info and `--version`, and is bumped to 1.4.0.

Verified end-to-end against a fake LSP driven by a fake agent: the LSP received `{"name":"claude-code (lsp-mcp ...)","version":"2.0.42"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)